### PR TITLE
Fixed n_jobs errors for umap-learn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: umap
 Title: Uniform Manifold Approximation and Projection
-Version: 0.2.10.1
+Version: 0.2.11.0
 Authors@R: 
     person("Tomasz", "Konopka", , "tokonopka@gmail.com", role = c("aut", "cre"))
 Author: Tomasz Konopka [aut, cre]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: umap
 Title: Uniform Manifold Approximation and Projection
-Version: 0.2.10.0
+Version: 0.2.10.1
 Authors@R: 
     person("Tomasz", "Konopka", , "tokonopka@gmail.com", role = c("aut", "cre"))
 Author: Tomasz Konopka [aut, cre]

--- a/R/umap.R
+++ b/R/umap.R
@@ -184,7 +184,9 @@ umap <- function(d, config=umap.defaults,
   method <- config$method <- match.arg(method)
   config <- umap.prep.config(config, ...)
   d <- umap.prep.input(d, config)
-  set.seed(config$random_state)
+  if(!is.na(config$random_state)) {
+    set.seed(config$random_state)
+  }
   
   # perform the actual work with a specific umap implementation
   if (nrow(d)<=2) {

--- a/R/umap_checks.R
+++ b/R/umap_checks.R
@@ -112,7 +112,7 @@ umap.prep.config <- function(config=umap.defaults, ...) {
 
   if(config$method == "umap-learn" && "n_jobs" %in% names(config)) {
     if(!is.numeric(config$n_jobs) | length(config$n_jobs) > 1)
-      umap.error("n_jobs must be one numeric value: ", config$n_jobs
+      umap.error("n_jobs must be one numeric value: ", config$n_jobs)
 
     if(config$n_jobs < 1)
       umap.error("n_jobs must be a positive integer: ", config$n_jobs)

--- a/R/umap_checks.R
+++ b/R/umap_checks.R
@@ -12,7 +12,7 @@
 umap.prep.config <- function(config=umap.defaults, ...) {
 
   umap.check.config.class(config)
-  
+
   # transfer values from arguments into the config object
   arguments <- list(...)
   for (onearg in names(arguments)) {
@@ -55,7 +55,7 @@ umap.prep.config <- function(config=umap.defaults, ...) {
     umap.warning(
       "parameter 'b' is set but 'a' is not;\n",
       "value of 'b' will be ignored.\n",
-      "(Embedding will be controlled via 'min_dist' and 'spread')") 
+      "(Embedding will be controlled via 'min_dist' and 'spread')")
   }
   if (!identical(config$a, NA) & !identical(config$b, NA)) {
     abcontrol <- "(Embedding will be controlled via 'a' and 'b')"
@@ -76,13 +76,13 @@ umap.prep.config <- function(config=umap.defaults, ...) {
   if (config$min_dist <=0) {
     umap.error("setting 'min_dist' must be > 0")
   }
-  
+
   # force some data types
   for (x in c("n_epochs", "n_neighbors", "n_components",
               "random_state", "negative_sample_rate", "transform_state")) {
     config[[x]] <- as.integer(config[[x]])
   }
-  
+
   # always give a metric name
   if (is(config$metric, "function")) {
     config$metric.function <- config$metric
@@ -106,20 +106,36 @@ umap.prep.config <- function(config=umap.defaults, ...) {
     }
   }
 
-  if (is.na(config$random_state) && config$method != "umap-learn") {
-    config$random_state <- as.integer(runif(1, 0, 2^30))
-  }
 
-  if(config$method == "umap-learn" && "n_jobs" %in% names(config)) {
+  ## check n_jobs for method umap-learn
+  is_umap_learn <- "method" %in% names(config) &&
+    config$method == "umap-learn"
+  is_more_than_one_job <- F
+
+  if(is_umap_learn && "n_jobs" %in% names(config)) {
     if(!is.numeric(config$n_jobs) | length(config$n_jobs) > 1)
-      umap.error("n_jobs must be one numeric value: ", config$n_jobs
+      umap.error("n_jobs must be one numeric value: ", config$n_jobs)
 
     if(config$n_jobs < 1)
       umap.error("n_jobs must be a positive integer: ", config$n_jobs)
 
     if(!is.integer(config$n_jobs))
       config$n_jobs <- as.integer(config$n_jobs)
+
+    if(config$n_jobs > 1L)
+      is_more_than_one_job <- T
   }
+
+  if(is_umap_learn && !"n_jobs" %in% names(config)) {
+    config$n_jobs <- 1L
+  }
+
+  ## set random state when NA and naive or n_jobs == 1
+  if (is.na(config$random_state) &&
+      (!is_umap_learn || !is_more_than_one_job)) {
+    config$random_state <- as.integer(runif(1, 0, 2^30))
+  }
+
 
   config
 }
@@ -144,7 +160,7 @@ umap.prep.input <- function(d, config) {
   }
   # ensure data is numeric (not integer or other data type)
   d[, 1] <- as.numeric(d[, 1])
-  
+
   # perhaps adjust the data matrix
   if (config$metric %in% c("pearson", "pearson2")) {
     # for pearson correlation distance, center by-sample
@@ -152,7 +168,7 @@ umap.prep.input <- function(d, config) {
     d <- t(d)
     d <- t(d) - apply(d, 2, mean)
   }
-  
+
   d
 }
 

--- a/R/umap_checks.R
+++ b/R/umap_checks.R
@@ -106,8 +106,19 @@ umap.prep.config <- function(config=umap.defaults, ...) {
     }
   }
 
-  if (is.na(config$random_state)) {
+  if (is.na(config$random_state) && config$method != "umap-learn") {
     config$random_state <- as.integer(runif(1, 0, 2^30))
+  }
+
+  if(config$method == "umap-learn" && "n_jobs" %in% names(config)) {
+    if(!is.numeric(config$n_jobs) | length(config$n_jobs) > 1)
+      umap.error("n_jobs must be one numeric value: ", config$n_jobs
+
+    if(config$n_jobs < 1)
+      umap.error("n_jobs must be a positive integer: ", config$n_jobs)
+
+    if(!is.integer(config$n_jobs))
+      config$n_jobs <- as.integer(config$n_jobs)
   }
 
   config


### PR DESCRIPTION
The warning `UserWarning: n_jobs value -1 overridden to 1 by setting random_state. Use no seed for parallelism.` occurs even when random_state is not set (= `NA`). 

```r
reticulate::use_condaenv("r-reticulate")
reticulate::py_install("umap-learn")

set.seed(123)
ds_train <- matrix(nrow = 1000,
                   ncol = 50,
                   runif(1000 * 50))

umap_model <- umap::umap(ds_train,
                         method = "umap-learn",
                         n_neighbors = 2,
                         n_components = 2,
                         metric = "cosine",
                         min_dist = .1,
                         spread = 1,
                         n_jobs = 12L,
                         
                         init = "random",
                         random_state = NA,
                         transform_state = NA,
                         verbose = TRUE)
```

This request fixes the error messages and allows parallel jobs. 